### PR TITLE
Support extra arguments to acme.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The command below works for GoDaddy DNS:
 sudo /config/scripts/renew.acme.sh -d subdomain.example.com -n dns_gd -t "GD_Key" -t "GD_Secret" -k "sdfsdfsdfljlbjkljlkjsdfoiwje" -k "asdfsdafdsfdsfdsfdsfdsafd"
 ```
 
+If you need extra arguments to acme.sh (perhaps for a [challenge alias](https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode)) specify them at the end after a ```--```:
+```
+sudo /config/scripts/renew.acme.sh -d subdomain.example.com -n dns_gd -t "GD_Key" -t "GD_Secret" -k "sdfsdfsdfljlbjkljlkjsdfoiwje" -k "asdfsdafdsfdsfdsfdsfdsafd" -- --challenge-alias challenge-domain.example.com
+```
+
 ## Configure router
 
 1. Set domain pointing to router internal IP address

--- a/renew.acme.sh
+++ b/renew.acme.sh
@@ -72,7 +72,7 @@ $ACMEHOME/acme.sh --issue $DNSARG $DOMAINARG --home $ACMEHOME \
     --keylength ec-384 --keypath /tmp/server.key --fullchainpath /tmp/full.cer \
     --log /var/log/acme.log \
     --reloadcmd /config/scripts/reload.acme.sh \
-    $INSECURE_FLAG $VERBOSE_FLAG
+    $INSECURE_FLAG $VERBOSE_FLAG $@
 
 log "Starting gui service."
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
I need a challenge alias for my domains, but rather than one-off that I figure why not just allow passing extra arbitrary args down to acme.sh.