### PR TITLE
updates for proper CA chaining (i.e. lighttpd actually presents the i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ If the update *fails* and you need to restart the web server:
 sudo /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
 ```
 
+<b>If your EdgeOS has outdated Let's Encrypt certificates, you'll need to also update these manually:</b>
+```
+sudo sed -i 's|^mozilla\/DST_Root_CA_X3\.crt|!mozilla/DST_Root_CA_X3.crt|' /etc/ca-certificates.conf
+sudo curl -sk https://letsencrypt.org/certs/isrgrootx1.pem -o /usr/local/share/ca-certificates/ISRG_Root_X1.crt
+sudo update-ca-certificates --fresh
+```
+
 ## Configure router
 
 1. Set domain pointing to router internal IP address
@@ -80,6 +87,7 @@ sudo /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
 
 	```
 	set service gui cert-file /config/ssl/server.pem
+    set service gui ca-file /config/ssl/ca.pem
 	```
 
 4. Commit and save your configuration

--- a/reload.acme.sh
+++ b/reload.acme.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 mkdir -p /config/ssl
-cat /tmp/server.key /tmp/full.cer > /config/ssl/server.pem
-rm /tmp/server.key /tmp/full.cer
+cat /tmp/key.pem /tmp/cert.pem > /config/ssl/server.pem
+cp /tmp/fullchain.pem /config/ssl/ca.pem
+rm /tmp/key.pem /tmp/cert.pem /tmp/fullchain.pem

--- a/renew.acme.sh
+++ b/renew.acme.sh
@@ -73,10 +73,10 @@ if [ -e "/var/run/lighttpd.pid" ]; then
 fi
 
 log "Executing acme.sh."
-$ACMEHOME/acme.sh --issue $DNSARG $DOMAINARG --home $ACMEHOME \
-    --keylength ec-384 --keypath /tmp/server.key --fullchainpath /tmp/full.cer \
-    --log /var/log/acme.log \
-    --reloadcmd /config/scripts/reload.acme.sh \
+$ACMEHOME/acme.sh --issue $DNSARG $DOMAINARG --home $ACMEHOME --server letsencrypt \
+    --keylength ec-384 --keypath /tmp/key.pem --certpath /tmp/cert.pem \
+    --fullchainpath /tmp/fullchain.pem --log /var/log/acme.log \
+    --reloadcmd /config/scripts/reload.acme.sh --force \
     $INSECURE_FLAG $VERBOSE_FLAG $@
 
 log "Starting gui service."

--- a/renew.acme.sh
+++ b/renew.acme.sh
@@ -76,7 +76,7 @@ log "Executing acme.sh."
 $ACMEHOME/acme.sh --issue $DNSARG $DOMAINARG --home $ACMEHOME --server letsencrypt \
     --keylength ec-384 --keypath /tmp/key.pem --certpath /tmp/cert.pem \
     --fullchainpath /tmp/fullchain.pem --log /var/log/acme.log \
-    --reloadcmd /config/scripts/reload.acme.sh --force \
+    --reloadcmd /config/scripts/reload.acme.sh \
     $INSECURE_FLAG $VERBOSE_FLAG $@
 
 log "Starting gui service."


### PR DESCRIPTION
…ntermediate certs properly to clients) and set Acme default back to LE.  I also added default provider as Lets Encrypt because the other ones fail due to old certs on EdgeOS.  I put instructions on how to update certs from LE in your readme. 

Bundling the cert, key and intermediates does not work.  You can validate this with openssl:

% openssl s_client -connect 192.168.1.1:443 -servername router.yourdomain.com

If you don't see the chain being delivered and: Verification: OK, then it's messed up.  The original author had this split out for a reason.  

% openssl s_client -connect 192.168.1.1:443 -servername router.yourdomain.com
CONNECTED(00000003)
depth=2 C = US, O = Internet Security Research Group, CN = ISRG Root X1
verify return:1
depth=1 C = US, O = Let's Encrypt, CN = R3
verify return:1
depth=0 CN = router.yourdomain.com
verify return:1
Certificate chain
 0 s:CN = router.yourdomain.com
   i:C = US, O = Let's Encrypt, CN = R3
 1 s:C = US, O = Let's Encrypt, CN = R3
   i:C = US, O = Internet Security Research Group, CN = ISRG Root X1
 2 s:C = US, O = Internet Security Research Group, CN = ISRG Root X1
   i:O = Digital Signature Trust Co., CN = DST Root CA X3
...
SSL handshake has read 4385 bytes and written 439 bytes
Verification: OK