### PR TITLE
Use Let's Encrypt for acme.sh

### DIFF
--- a/renew.acme.sh
+++ b/renew.acme.sh
@@ -77,7 +77,7 @@ $ACMEHOME/acme.sh --issue $DNSARG $DOMAINARG --home $ACMEHOME \
     --keylength ec-384 --keypath /tmp/server.key --fullchainpath /tmp/full.cer \
     --log /var/log/acme.log \
     --reloadcmd /config/scripts/reload.acme.sh \
-    $INSECURE_FLAG $VERBOSE_FLAG $@
+    $INSECURE_FLAG $VERBOSE_FLAG --server letsencrypt $@
 
 log "Starting gui service."
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
Since August 2021, [acme.sh uses ZeroSSL by default](https://github-wiki-see.page/m/acmesh-official/acme.sh/wiki/Change-default-CA-to-ZeroSSL), which causes renew.acme.sh for a new installation to fail. This sets the "--server letsencrypt" flag to force acme.sh to use Let's Encrypt.